### PR TITLE
fix syntax for fish 3.1

### DIFF
--- a/lol.fish
+++ b/lol.fish
@@ -100,8 +100,8 @@ function fish_prompt
     # TODO: use git's built in prompt support
     if command -s git > /dev/null 2>&1
         if git rev-parse --git-dir > /dev/null 2>&1
-            set -l git_branch (git rev-parse --abbrev-ref HEAD >/dev/null)
-            set -l git_status (count (git status -s --ignore-submodules >/dev/null))
+            set -l git_branch (git rev-parse --abbrev-ref HEAD 2>/dev/null)
+            set -l git_status (count (git status -s --ignore-submodules 2>/dev/null))
             if test $git_status -gt 0
                 set git_dir '[' $git_branch ':' $git_status ']'
             else

--- a/lol.fish
+++ b/lol.fish
@@ -155,8 +155,8 @@ function fish_right_prompt
     # Display the time and date
     #
     if command -s date > /dev/null 2>&1
-        set time (date +'%H:%M' >/dev/null)
-        set date (date +'%d-%m-%Y' >/dev/null)
+        set time (date +'%H:%M' 2>/dev/null)
+        set date (date +'%d-%m-%Y' 2>/dev/null)
     end
 
     lolfish $background_jobs_prompt $tmux_sessions_prompt $time ' ' $date

--- a/lol.fish
+++ b/lol.fish
@@ -91,7 +91,7 @@ function fish_prompt
 
     # abbreviated home directory ~
     if command -s sed > /dev/null 2>&1
-        set current_dir (echo $PWD | sed -e "s,.*$HOME,~," >/dev/null)
+        set current_dir (echo $PWD | sed -e "s,.*$HOME,~," 2>/dev/null)
     else
         set current_dir $PWD
     end

--- a/lol.fish
+++ b/lol.fish
@@ -90,18 +90,18 @@ function fish_prompt
     end
 
     # abbreviated home directory ~
-    if command -s sed > /dev/null ^&1
-        set current_dir (echo $PWD | sed -e "s,.*$HOME,~," ^/dev/null)
+    if command -s sed > /dev/null >&1
+        set current_dir (echo $PWD | sed -e "s,.*$HOME,~," >/dev/null)
     else
         set current_dir $PWD
     end
 
     # the git stuff
     # TODO: use git's built in prompt support
-    if command -s git > /dev/null ^&1
-        if git rev-parse --git-dir > /dev/null ^&1
-            set -l git_branch (git rev-parse --abbrev-ref HEAD ^/dev/null)
-            set -l git_status (count (git status -s --ignore-submodules ^/dev/null))
+    if command -s git > /dev/null >&1
+        if git rev-parse --git-dir > /dev/null >&1
+            set -l git_branch (git rev-parse --abbrev-ref HEAD >/dev/null)
+            set -l git_status (count (git status -s --ignore-submodules >/dev/null))
             if test $git_status -gt 0
                 set git_dir '[' $git_branch ':' $git_status ']'
             else
@@ -133,7 +133,7 @@ function fish_right_prompt
     #
     # background jobs
     #
-    set -l background_jobs (count (jobs -p ^/dev/null))
+    set -l background_jobs (count (jobs -p >/dev/null))
     if test $background_jobs -gt 0
         set background_jobs_prompt '[' '&' ':' $background_jobs ']'
     end
@@ -143,8 +143,8 @@ function fish_right_prompt
     # only if the shell is running outside of tmux
     #
     if test -z $TMUX
-        if command -s tmux > /dev/null ^&1
-            set -l tmux_sessions (count (tmux list-sessions ^/dev/null))
+        if command -s tmux > /dev/null >&1
+            set -l tmux_sessions (count (tmux list-sessions >/dev/null))
             if test $tmux_sessions -gt 0
                 set tmux_sessions_prompt '[' 'tmux' ':' $tmux_sessions ']'
             end
@@ -154,9 +154,9 @@ function fish_right_prompt
     #
     # Display the time and date
     #
-    if command -s date > /dev/null ^&1
-        set time (date +'%H:%M' ^/dev/null)
-        set date (date +'%d-%m-%Y' ^/dev/null)
+    if command -s date > /dev/null >&1
+        set time (date +'%H:%M' >/dev/null)
+        set date (date +'%d-%m-%Y' >/dev/null)
     end
 
     lolfish $background_jobs_prompt $tmux_sessions_prompt $time ' ' $date

--- a/lol.fish
+++ b/lol.fish
@@ -90,7 +90,7 @@ function fish_prompt
     end
 
     # abbreviated home directory ~
-    if command -s sed > /dev/null >&1
+    if command -s sed > /dev/null 2>&1
         set current_dir (echo $PWD | sed -e "s,.*$HOME,~," >/dev/null)
     else
         set current_dir $PWD
@@ -98,8 +98,8 @@ function fish_prompt
 
     # the git stuff
     # TODO: use git's built in prompt support
-    if command -s git > /dev/null >&1
-        if git rev-parse --git-dir > /dev/null >&1
+    if command -s git > /dev/null 2>&1
+        if git rev-parse --git-dir > /dev/null 2>&1
             set -l git_branch (git rev-parse --abbrev-ref HEAD >/dev/null)
             set -l git_status (count (git status -s --ignore-submodules >/dev/null))
             if test $git_status -gt 0
@@ -143,7 +143,7 @@ function fish_right_prompt
     # only if the shell is running outside of tmux
     #
     if test -z $TMUX
-        if command -s tmux > /dev/null >&1
+        if command -s tmux > /dev/null 2>&1
             set -l tmux_sessions (count (tmux list-sessions >/dev/null))
             if test $tmux_sessions -gt 0
                 set tmux_sessions_prompt '[' 'tmux' ':' $tmux_sessions ']'
@@ -154,7 +154,7 @@ function fish_right_prompt
     #
     # Display the time and date
     #
-    if command -s date > /dev/null >&1
+    if command -s date > /dev/null 2>&1
         set time (date +'%H:%M' >/dev/null)
         set date (date +'%d-%m-%Y' >/dev/null)
     end


### PR DESCRIPTION
replace all `^` with `>` to not use removed syntax