### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/lol.fish
+++ b/lol.fish
@@ -90,18 +90,18 @@ function fish_prompt
     end
 
     # abbreviated home directory ~
-    if command -s sed > /dev/null ^&1
-        set current_dir (echo $PWD | sed -e "s,.*$HOME,~," ^/dev/null)
+    if command -s sed > /dev/null 2>&1
+        set current_dir (echo $PWD | sed -e "s,.*$HOME,~," 2>/dev/null)
     else
         set current_dir $PWD
     end
 
     # the git stuff
     # TODO: use git's built in prompt support
-    if command -s git > /dev/null ^&1
-        if git rev-parse --git-dir > /dev/null ^&1
-            set -l git_branch (git rev-parse --abbrev-ref HEAD ^/dev/null)
-            set -l git_status (count (git status -s --ignore-submodules ^/dev/null))
+    if command -s git > /dev/null 2>&1
+        if git rev-parse --git-dir > /dev/null 2>&1
+            set -l git_branch (git rev-parse --abbrev-ref HEAD 2>/dev/null)
+            set -l git_status (count (git status -s --ignore-submodules 2>/dev/null))
             if test $git_status -gt 0
                 set git_dir '[' $git_branch ':' $git_status ']'
             else
@@ -133,7 +133,7 @@ function fish_right_prompt
     #
     # background jobs
     #
-    set -l background_jobs (count (jobs -p ^/dev/null))
+    set -l background_jobs (count (jobs -p 2>/dev/null))
     if test $background_jobs -gt 0
         set background_jobs_prompt '[' '&' ':' $background_jobs ']'
     end
@@ -143,8 +143,8 @@ function fish_right_prompt
     # only if the shell is running outside of tmux
     #
     if test -z $TMUX
-        if command -s tmux > /dev/null ^&1
-            set -l tmux_sessions (count (tmux list-sessions ^/dev/null))
+        if command -s tmux > /dev/null 2>&1
+            set -l tmux_sessions (count (tmux list-sessions 2>/dev/null))
             if test $tmux_sessions -gt 0
                 set tmux_sessions_prompt '[' 'tmux' ':' $tmux_sessions ']'
             end
@@ -154,9 +154,9 @@ function fish_right_prompt
     #
     # Display the time and date
     #
-    if command -s date > /dev/null ^&1
-        set time (date +'%H:%M' ^/dev/null)
-        set date (date +'%d-%m-%Y' ^/dev/null)
+    if command -s date > /dev/null 2>&1
+        set time (date +'%H:%M' 2>/dev/null)
+        set date (date +'%d-%m-%Y' 2>/dev/null)
     end
 
     lolfish $background_jobs_prompt $tmux_sessions_prompt $time ' ' $date


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
